### PR TITLE
[WIP]Chatspace:DB設計（READMEのUPDATE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,3 +65,5 @@ Things you may want to cover:
 ### Association
 - belongs_to :group
 - belongs_to :user
+- has_many :groups
+- has_many :users

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
-- belongs_to :group
+- has_many :groups, through: :groups_users
 
 
 ## messagesテーブル
@@ -56,7 +56,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
-- belongs_to :user
+- has_many :users, through: :groups_users
 
 ## groups_usersテーブル
 
@@ -64,3 +64,7 @@ Things you may want to cover:
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :groups, through: :groups_users
-- belongs_to :groups_users
+- has_many :groups_users
 
 
 
@@ -59,7 +59,7 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :users, through: :groups_users
-- belongs_to :groups_users
+- has_many :groups_users
 
 
 ## groups_usersテーブル
@@ -70,5 +70,5 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- has_many :groups
-- has_many :users
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -65,5 +65,3 @@ Things you may want to cover:
 ### Association
 - belongs_to :group
 - belongs_to :user
-- has_many :groups
-- has_many :users

--- a/README.md
+++ b/README.md
@@ -22,3 +22,46 @@ Things you may want to cover:
 * Deployment instructions
 
 * ...
+
+# Chatspace DB設計
+## usersテーブル
+|Column|Type|Options|
+|------|----|-------|
+|name|string|null: false|
+|email|string|null: false, unique:true|
+|password|string|null: false|
+
+### Association
+- has_many :messages
+
+## messagesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|message|text|null: false|
+|image|string|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :user
+- belongs_to :group
+
+## groupsテーブル
+|Column|Type|Options|
+|------|----|-------|
+|group_name|string|null: false|
+|member|string|null: false|
+
+### Association
+- has_many :messages
+
+## groups_usersテーブル
+
+|Column|Type|Options|
+|------|----|-------|
+|user_id|integer|null: false, foreign_key: true|
+|group_id|integer|null: false, foreign_key: true|
+
+### Association
+- belongs_to :group
+- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
+- belongs_to :group
+
 
 ## messagesテーブル
 |Column|Type|Options|
@@ -54,6 +56,7 @@ Things you may want to cover:
 
 ### Association
 - has_many :messages
+- belongs_to :user
 
 ## groups_usersテーブル
 
@@ -61,7 +64,3 @@ Things you may want to cover:
 |------|----|-------|
 |user_id|integer|null: false, foreign_key: true|
 |group_id|integer|null: false, foreign_key: true|
-
-### Association
-- belongs_to :group
-- belongs_to :user

--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :groups, through: :groups_users
+- belongs_to :groups_users
+
 
 
 ## messagesテーブル
@@ -57,6 +59,8 @@ Things you may want to cover:
 ### Association
 - has_many :messages
 - has_many :users, through: :groups_users
+- belongs_to :groups_users
+
 
 ## groups_usersテーブル
 
@@ -66,5 +70,5 @@ Things you may want to cover:
 |group_id|integer|null: false, foreign_key: true|
 
 ### Association
-- belongs_to :group
-- belongs_to :user
+- has_many :groups
+- has_many :users


### PR DESCRIPTION
 #what　（※カリキュラム：lesson7データベース設計-chatspaceのデータベース設計）
Markdown記法で、DB設計をしました。テーブルは４つ。（１）usersテーブル、（２）messagesテーブル （３） groupsテーブル（４）groups_usersテーブルです。（４）は中間テーブルです。

#why
●エンティティ洗い出し後、上記テーブルを作成し制約について考えました。
●空白入力を不可とするものにはNOTNULL制約を記載し、emailカラムには一意性制約をつけました。user_idとgroup_idは外部キー制約をつけました。
●アソシエーションについて。１対多で組んだもの：usersテーブルとmessagesテーブル間　/　groupsテーブルとmessagesテーブル間。usersテーブルとgroupsテーブル間は互いに多対多と考え、中間テーブルで定義しました。
●インデックスのデータ検索機能について検討しましたが、インデックスのデメリット（データを保存・更新する速度が遅くなる・データベースの容量を使う）を考え設定しませんでした。


