### PR TITLE
jsファイルの作成・フォーム送信後のイベント発火

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,5 @@
 $(function(){
+  $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action');

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,0 +1,14 @@
+$(function(){
+    e.preventDefault();
+    var formData = new FormData(this);
+    var url = $(this).attr('action');
+    $.ajax({
+      url: url,
+      type: "POST",
+      data: formData,
+      dataType: 'json',
+      processData: false,
+      contentType: false
+    })
+  });
+});

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,6 +7,7 @@ class MessagesController < ApplicationController
   end
 
   def create
+    # binding.pry
     @message = @group.messages.new(message_params)
     if @message.save
       redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -7,7 +7,6 @@ class MessagesController < ApplicationController
   end
 
   def create
-    # binding.pry
     @message = @group.messages.new(message_params)
     if @message.save
       redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -18,7 +18,7 @@
   .messages
 
     = render @messages
-
+    
   .form
     = form_for [@group, @message] do |f|
       .input-box


### PR DESCRIPTION
# What
- jsファイルを作成する
- フォームが送信されたら、イベントが発火するようにjsに記述する


 
# why 
__メッセージ投稿機能の非同期通信を行えるようにするため__
- Ajaxを含むJS（jQuery)処理を記述していく

