### PR TITLE
メッセージコントローラー修正（respond_toで場合分け、doneメソッド）・jbuilder作成

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -35,7 +35,6 @@ $(function(){
       contentType: false
     })
     .done(function(data){
-      console.log(data)
       var html = buildHTML(data);
       $('.messages').append(html);  
       $('form')[0].reset();

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,4 +1,44 @@
 $(function(){
+  function buildHTML(message){
+    if ( message.image ) {
+      var html =
+        `<div class="message" data-message-id=${message.id}>
+            <div class="message__update-info">
+              <p class="message__update-info__talker">
+                ${message.user_name}
+              </p>
+              <p class="message__update-info__date">
+                ${message.date}
+              </p>
+            </div>
+            <div class="lowewr-message">
+              <p class="message__text">
+                ${message.message}
+              </p>
+            </div>
+              <img src=${message.image} >
+            </div>`
+          return html;
+    } else {
+      var html =
+        `<div class="message" data-message-id=${message.id}>
+            <div class="upper-message">
+              <div class="upper-message__user-name">
+                ${message.user_name}
+              </div>
+              <div class="upper-message__date">
+                ${message.date}
+              </div>
+            </div>
+            <div class="lower-message">
+              <p class="lower-message__content">
+                ${message.content}
+              </p>
+            </div>
+          </div>`
+        return html;
+  };
+}
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -10,6 +50,12 @@ $(function(){
       dataType: 'json',
       processData: false,
       contentType: false
+    })
+    .done(function(data){
+      var html = buildHTML(data);
+    })
+    .fail(function(){
+      alert('error');
     })
   });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,6 +1,7 @@
 $(function(){
   function buildHTML(message){
-    if ( message.image ) {
+    let image = message.image ? message.image :'';
+
       var html =
         `<div class="message" data-message-id=${message.id}>
             <div class="message__update-info">
@@ -16,29 +17,11 @@ $(function(){
                 ${message.message}
               </p>
             </div>
-              <img src=${message.image} >
+              <img src=${image} >
             </div>`
           return html;
-    } else {
-      var html =
-        `<div class="message" data-message-id=${message.id}>
-            <div class="upper-message">
-              <div class="upper-message__user-name">
-                ${message.user_name}
-              </div>
-              <div class="upper-message__date">
-                ${message.date}
-              </div>
-            </div>
-            <div class="lower-message">
-              <p class="lower-message__content">
-                ${message.content}
-              </p>
-            </div>
-          </div>`
-        return html;
-  };
-}
+    } 
+    
   $('#new_message').on('submit',function(e){
     e.preventDefault();
     var formData = new FormData(this);
@@ -52,10 +35,13 @@ $(function(){
       contentType: false
     })
     .done(function(data){
+      console.log(data)
       var html = buildHTML(data);
+      $('.messages').append(html);  
+      $('form')[0].reset();
     })
     .fail(function(){
       alert('error');
     })
-  });
+  })
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -9,12 +9,15 @@ class MessagesController < ApplicationController
   def create
     @message = @group.messages.new(message_params)
     if @message.save
-      redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'
+      respond_to do |format|
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'  }
+        format.json
+      end
     else
       @messages = @group.messages.includes(:user)
       flash.now[:alert] = 'メッセージを入力してください。'
       render :index
-    end
+    end 
   end
 
   private

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -1,7 +1,7 @@
 class Message < ApplicationRecord
-  # mount_uploader :image, ImageUploader
   belongs_to :group
   belongs_to :user
+  mount_uploader :image, ImageUploader
   validates :message, presence: true, unless: :image?
 end
 

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,4 +2,4 @@ json.id  @message.id
 json.user_name  @message.user.name
 json.data  @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
 json.message  @message.message
-json.image  @message.image
+json.image  @message.image.url

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,0 +1,5 @@
+json.id  @message.id
+json.user_name  @message.user.name
+json.data  @message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+json.message  @message.message
+json.image  @message.image


### PR DESCRIPTION
# what
- イベントが発火したときにAjaxを使用して、messages#createが動くようにする
- messages#createでメッセージを保存し、respond_toを使用してHTMLとJSONの場合で処理を分ける
- jbuilderを使用して、作成したメッセージをJSON形式で返す

# why
__メッセージ投稿機能の非同期通信を行えるようにするため__
- 発火後、リクエストをコントローラーからサーバーへajaxで送る。
- サーバーからのレスポンスをJSON(jbuilder)で受け取る。
