### PR TITLE
メッセージのスクロール、非同期に失敗した場合を記述

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -9,7 +9,7 @@ $(function(){
                 ${message.user_name}
               </p>
               <p class="message__update-info__date">
-                ${message.date}
+                ${message.data}
               </p>
             </div>
             <div class="lowewr-message">
@@ -26,6 +26,7 @@ $(function(){
     e.preventDefault();
     var formData = new FormData(this);
     var url = $(this).attr('action');
+   
     $.ajax({
       url: url,
       type: "POST",
@@ -36,11 +37,13 @@ $(function(){
     })
     .done(function(data){
       var html = buildHTML(data);
-      $('.messages').append(html);  
+      $('.messages').append(html);
+      $('.messages').animate({scrollTop: $('.messages')[0].scrollHeight}, 'fast');    
       $('form')[0].reset();
     })
     .fail(function(){
       alert('error');
-    })
-  })
+    });
+    return false;
+  });
 });

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -10,7 +10,7 @@ class MessagesController < ApplicationController
     @message = @group.messages.new(message_params)
     if @message.save
       respond_to do |format|
-        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました'  }
+        format.html { redirect_to group_messages_path(@group), notice: 'メッセージが送信されました' }
         format.json
       end
     else


### PR DESCRIPTION
# what
message.jsに下記の記述をした
- 画面を下にスクロールする記述をする
- 連続で送信ボタンを押せる記述をする
- 非同期に失敗した場合のエラーのアラートの記述する

# why
__メッセージ投稿機能の非同期通信を行えるようにするため__
- HTMLを追加した分、自動でメッセージ画面を最下部までスクロールできるようにするため
- 2回目の投稿時、ブラウザをリロードしなくても画面上にメッセージを表示できるようにするため
- 非同期に失敗した場合、ユーザーにエラーを知らせるようにするため
