### PR TITLE
インクリメンタルサーチ後の実装(既存のユーザーが追加済みの状態を確認)

### DIFF
--- a/app/assets/javascripts/index.js
+++ b/app/assets/javascripts/index.js
@@ -23,14 +23,6 @@ $(function(){
                 return ht;
   };
 
-  function buildHTML4(rname,rid){
-    var h = `<div class="chat-group-user clearfix">
-                  <p class="chat-group-user__name">${ rname } </p>
-                  <div class="user-search-add chat-group-user__btn chat-group-user__btn--add" data-user-id="${ rid }" data-user-name="${ rname}">追加</div>
-                </div>`
-                return h;
-  };
-
   $("#user-search-field").on("keyup", function(){
     var input = $("#user-search-field").val();
     $.ajax({

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -30,6 +30,7 @@ class GroupsController < ApplicationController
     end
   end
 
+  
  private
   def group_params
     params.require(:group).permit(:name, { :user_ids => [] })
@@ -38,4 +39,5 @@ class GroupsController < ApplicationController
   def set_group
     @group = Group.find(params[:id])
   end
+  
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,6 @@ class UsersController < ApplicationController
     @users = User.where('name LIKE(?)', "%#{params[:keyword]}%").where.not(id: current_user)
     
     respond_to do |format|
-      format.html
       format.json
     end
   end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -16,7 +16,7 @@
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
         %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
-        #user-search-result
+      #user-search-result
 
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
@@ -24,7 +24,17 @@
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
     .chat-group-form__field--right
       .chat-group-form__chatmember.clearfix
-        #chat-member-add
+        .chat-group-user
+          %input{name: "group[user_ids][]", type: "hidden", value:current_user.id }/
+          %p.chat-group-user__name 
+          = current_user.name
+      - group.users.each do |member|
+        - if member[:name] != current_user.name
+          .chat-group-user
+            %input{name:"group[user_ids][]", type: "hidden", value: member[:id]}/
+            .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除
+            %p= member[:name]
+          #chat-member-add
 
       / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
       

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -16,7 +16,7 @@
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
         %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
-      #user-search-result
+        #user-search-result
 
     / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
@@ -28,6 +28,8 @@
           %input{name: "group[user_ids][]", type: "hidden", value:current_user.id }/
           %p.chat-group-user__name 
           = current_user.name
+        #chat-member-add
+
       - group.users.each do |member|
         - if member[:name] != current_user.name
           .chat-group-user

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -31,7 +31,7 @@
         #chat-member-add
 
       - group.users.each do |member|
-        - if member[:name] != current_user.name
+        - if member[:id] != current_user.id
           .chat-group-user
             %input{name:"group[user_ids][]", type: "hidden", value: member[:id]}/
             .user-search-remove.chat-group-user__btn.chat-group-user__btn--remove.js-remove-btn 削除

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -18,7 +18,6 @@
         %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください", type: "text"}/
         #user-search-result
 
-    / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       %label.chat-group-form__label{for: "chat_group_チャットメンバー"} チャットメンバー
@@ -38,9 +37,6 @@
             %p= member[:name]
           #chat-member-add
 
-      / グループ作成機能の追加時はここにcollection_check_boxesの記述を入れてください
-      
-      / この部分はインクリメンタルサーチ（ユーザー追加の非同期化のときに使用します
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right


### PR DESCRIPTION
# what
-  編集画面では既存のユーザーが追加済みの状態であることを確認する
>グループ作成、編集画面でcurrent_userを固定表示(_form.html.hamlでcurrent_userを使う)
>編集画面にアクセスした時に、既にグループに追加されているユーザーは、最初から追加済みの状態である。（_form.html.hamlでeach doとifを使う)



# why
__インクリメンタルサーチを実装し、検索を非同期で行えるようにするため__
-  編集画面では既存のユーザーが追加済みの状態であることを確認する

